### PR TITLE
MOB-398 - Buttons with two lines

### DIFF
--- a/designsystem/src/main/java/cmm/apps/designsystem/EsmorgaButton.kt
+++ b/designsystem/src/main/java/cmm/apps/designsystem/EsmorgaButton.kt
@@ -17,6 +17,7 @@ fun EsmorgaButton(
     isLoading: Boolean = false,
     isEnabled: Boolean = true,
     primary: Boolean = true,
+    oneLine: Boolean = false,
     onClick: () -> Unit
 ) {
     Button(
@@ -36,7 +37,7 @@ fun EsmorgaButton(
         if (isLoading) {
             EsmorgaCircularLoader(modifier = Modifier.size(24.dp))
         } else {
-            EsmorgaText(text = text, style = EsmorgaTextStyle.BUTTON)
+            EsmorgaText(text = text, style = EsmorgaTextStyle.BUTTON, maxLines = if (oneLine) 1 else Int.MAX_VALUE)
         }
     }
 

--- a/designsystem/src/main/java/cmm/apps/designsystem/EsmorgaDialog.kt
+++ b/designsystem/src/main/java/cmm/apps/designsystem/EsmorgaDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.trace
 import androidx.compose.ui.window.Dialog
 
 @Composable
@@ -56,6 +57,7 @@ fun EsmorgaDialog(
                         onClick = {
                             onDismiss()
                         },
+                        oneLine = true,
                         modifier = modifier.weight(1F),
                         primary = false
                     )
@@ -63,6 +65,7 @@ fun EsmorgaDialog(
                     EsmorgaButton(
                         text = confirmButtonText,
                         modifier = modifier.weight(1F),
+                        oneLine = true,
                         onClick = {
                             onConfirm()
                         }

--- a/designsystem/src/main/java/cmm/apps/designsystem/EsmorgaDialog.kt
+++ b/designsystem/src/main/java/cmm/apps/designsystem/EsmorgaDialog.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.trace
 import androidx.compose.ui.window.Dialog
 
 @Composable

--- a/view/src/test/java/cmm/apps/esmorga/view/screenshot/profile/ProfileLogOutDialogViewScreenshotTest.kt
+++ b/view/src/test/java/cmm/apps/esmorga/view/screenshot/profile/ProfileLogOutDialogViewScreenshotTest.kt
@@ -21,4 +21,19 @@ class ProfileLogOutDialogViewScreenshotTest : BaseScreenshotTest() {
             }
         }
     }
+
+    @Test
+    fun logoutDialog_longText() {
+        paparazzi.snapshot {
+            EsmorgaTheme {
+                EsmorgaDialog(
+                    title = "Are you sure you want to log out?",
+                    confirmButtonText = "Yes, log out with long text",
+                    dismissButtonText = "No, cancel with long text",
+                    onConfirm = {},
+                    onDismiss = {}
+                )
+            }
+        }
+    }
 }

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.profile_ProfileLogOutDialogViewScreenshotTest_logoutDialog_default.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.profile_ProfileLogOutDialogViewScreenshotTest_logoutDialog_default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1fb02ca4d632bdc73a17ed51f1ddd2ebb8f6ae266c19163bda759b4170c00fd
-size 12436
+oid sha256:d9fc31bed1f2f411fe1a34ff639f1a9d26979ed6be9291214f0ce18e86edbfc5
+size 12626

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.profile_ProfileLogOutDialogViewScreenshotTest_logoutDialog_longText.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.profile_ProfileLogOutDialogViewScreenshotTest_logoutDialog_longText.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a1658c6c67ce9a236b37c6281c4f065034b7f673172ad6eecc06266c1c68018
+size 12756


### PR DESCRIPTION
The buttons in the profile dialog should be single-line