### PR TITLE
Updated test screenshots

### DIFF
--- a/.github/tmp/branch.txt
+++ b/.github/tmp/branch.txt
@@ -1,1 +1,1 @@
-feature/MOB-389
+fix/paparazzi-tests

--- a/view/src/test/java/cmm/apps/esmorga/view/screenshot/BaseScreenshotTest.kt
+++ b/view/src/test/java/cmm/apps/esmorga/view/screenshot/BaseScreenshotTest.kt
@@ -26,7 +26,8 @@ open class BaseScreenshotTest {
     val paparazzi = Paparazzi(
         deviceConfig = DeviceConfig.PIXEL_6,
         renderingMode = SessionParams.RenderingMode.NORMAL,
-        showSystemUi = false
+        showSystemUi = false,
+        maxPercentDifference = 0.01
     )
 
     @OptIn(ExperimentalCoilApi::class, ExperimentalCoroutinesApi::class)

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.activateAccount_ActivateAccountViewScreenshotTest_activateAccountView_lightTheme_idleState.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.activateAccount_ActivateAccountViewScreenshotTest_activateAccountView_lightTheme_idleState.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68d366e6c4daf5c65c19075a0fce8ed4bdd5c0551f7c6df03891b4ff6beb82f2
-size 253465
+oid sha256:c21d58ddf95ffe70cc1e6da586b1ef754bc5a63e0cd2485ba4bd30a3a97b496e
+size 253539

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.activateAccount_ActivateAccountViewScreenshotTest_activateAccountView_lightTheme_loadingState.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.activateAccount_ActivateAccountViewScreenshotTest_activateAccountView_lightTheme_loadingState.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:678aff147700ee02ae00b5167c7615010cc566e4cd245a1ec8101596a614cfcd
-size 251949
+oid sha256:9b499cb35c5da598ee1aa8ac317efe994b7ad8c3b370e368f47ecf5fc4159058
+size 252147

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.changepassword_ChangePasswordScreenShotTest_changePasswordView_lightTheme_empty.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.changepassword_ChangePasswordScreenShotTest_changePasswordView_lightTheme_empty.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd9b597c2ebec81acb71796a64ec487658271fe80f4d94c05ce002cb93cdc520
-size 30750
+oid sha256:fb359024f0beb1338c98e63083f3b733c6250b04f906f1179ba22b7ebf6ed2df
+size 30345

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.changepassword_ChangePasswordScreenShotTest_changePasswordView_lightTheme_passwords_errors.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.changepassword_ChangePasswordScreenShotTest_changePasswordView_lightTheme_passwords_errors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8072c8a87c7001cded94dc647f6d7d94cf33eabf3b3df67dfd162a2af99bff6
-size 39557
+oid sha256:39fe4f3c7b120ca70bf2b462cfc3459a1fee5a360a3f324fa0b470ab47bcc7cf
+size 38210

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.createEvent_CreateEventFormDateScreenScreenshotTest_createEventDateScreenDefault.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.createEvent_CreateEventFormDateScreenScreenshotTest_createEventDateScreenDefault.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb4295615823b89aee3c0d91dee8d434f59c00ce57dd18cc1df77a870e95240c
-size 27470
+oid sha256:015df1b050a6a5a9630ce1ccdbb2d4ee7b6ec92bae5239bb69f621897c10c82d
+size 26753

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.createEvent_CreateEventFormDateScreenScreenshotTest_createEventDateScreenWithButtonEnabled.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.createEvent_CreateEventFormDateScreenScreenshotTest_createEventDateScreenWithButtonEnabled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ad4aed3d849267d99f03bc915e3a5e2889c9733615ba16495bfe982e4b053c3
-size 27787
+oid sha256:a8d215c3cca8b3efccaa7c4716a8d719076e2b4c01c8684b0de90a94d589f7f5
+size 27074

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.error_FullErrorScreenshotTest_fullScreenErrorView_lightTheme_data.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.error_FullErrorScreenshotTest_fullScreenErrorView_lightTheme_data.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7deb46e86cdace4630d598757b47aea445ffa0b74557748d98f7811145657d9
-size 19182
+oid sha256:ebf2546a4539b29d0ed5d9e411b95cc97e73aa26b992df0396396dafb9b9c16b
+size 19151

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.error_FullErrorScreenshotTest_fullScreenNoInternetErrorView_lightTheme_data.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.error_FullErrorScreenshotTest_fullScreenNoInternetErrorView_lightTheme_data.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f74bab81d476e95c131386497d8789c1b61266a08fae2b53edf4251bf610fa1
-size 17740
+oid sha256:68759434a251a281eaf5c79dcd29d13008bde3ce464b32cb2bbbc29ee087e61b
+size 17646

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_data.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_data.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30eb73bd56397540fed09be26c08e56f28dd77cfdf3254442f48ad6d93efc392
-size 19959
+oid sha256:948f4a73d14418406fe56e23fbd375bdb45edab8cd70b0a92ccefe5756d14666
+size 19624

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_empty.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_empty.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bd3a7d498785f1f468419186d8a04a10394b63aad89a1ee2301a29487c6007a
-size 198593
+oid sha256:7a26d56bdf4955d5239df90f263064bddd05649edfd3df25e2aaac00007151b2
+size 198671

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_error.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_error.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d337e870362d02921a28ffe9cbe18d6b35b0eaaba96536c044f0fd2204c5d832
-size 14101
+oid sha256:b582adaf06c6942c128142d38aedc9e01d8154993eacf8b5680fc45cd8d51102
+size 14003

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_loading.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_EventListViewScreenshotTest_eventListView_lightTheme_loading.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:135e1d8fb2c0fdf05f6e10698957a3395c1e6e4434c7340e0c866276100cc6f7
-size 8780
+oid sha256:9694ed79e6a0773837628cd2e159b748a44e1eba5dbb7febf19824e3c8ea4db6
+size 8705

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_eventListView_lightTheme_data.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_eventListView_lightTheme_data.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33629ee7b7ed4bcaeafbb87a85fb21dc75688e65e0ae296e2c8de0bce8582b1c
-size 20741
+oid sha256:8a59410f9c2a57c3a610ab4b7481217d87696b82fef44f8e91b68fe808a76a1f
+size 20302

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_myEventListView_lightTheme_error_no_events_joined.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_myEventListView_lightTheme_error_no_events_joined.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4110e4b4f3ae76b94cd8cf7539a63f7d677aaf6a569686fcdb2e9f361f967c85
-size 18360
+oid sha256:bcd3898a2921be65ecdfcb9758ba04b7c4056652fb0840d5617a499fa3531314
+size 18058

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_myEventListView_lightTheme_loading.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_myEventListView_lightTheme_loading.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:980e203fe63f8ce96b72d675cdf1aa12aef7670f8b78998e77707f410374f33b
-size 9599
+oid sha256:0a841efae7e895480d2c55c547065572e719dd6b5ba3e3a9ff857efd94533f36
+size 9385

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_myEventListView_lightTheme_user_is_admin.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventList_MyEventListViewScreenshotTest_myEventListView_lightTheme_user_is_admin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:400b38587178e19f7eef92b2786941a52fb204388f179e7b94319be10e6ed689
-size 17639
+oid sha256:deaf1d161bc3c7717daba7ee47e5394b94b5919add458abf6e9b252542119345
+size 17365

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:901aecfd562f8a4ab950321802e3accdf09bc340fc7cb3bcf6441095a89ccbd2
-size 25940
+oid sha256:5641df7dbced3e2c727331ef710e1f152d2347e98562cd7310dff1fa78cc17bf
+size 25029

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data_primary_button_loading_state.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data_primary_button_loading_state.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:381bb3ef5f1ab861897a49e97a31c6f0c468f56de1efc999b1eebbf68abceee1
-size 22959
+oid sha256:06bae228caf24e9094ccf8ee647cdf25d730ec3fb3af16ac89301e0b93018ca9
+size 22647

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data_user_event_joined.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data_user_event_joined.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:837e6eecef3ef592700ef43cc01755db6a5b1eda00058628ba5c2bec4f2458bf
-size 25059
+oid sha256:700779b922aab493909941a65e587df3f8e3a9cd80306e12d800aa7e86e4e642
+size 24527

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data_user_event_not_joined.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_data_user_event_not_joined.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94e0e03ae0069c26ff5460ea0dcc20ce95315a0914d819f7f155298b178216ac
-size 24784
+oid sha256:069f885ce5717a8854a9ba0ab167c25eee87f6be563a643f1a659c87b7883c4b
+size 24306

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_no_location.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.eventdetails_EventDetailsScreenshotTest_eventDetailsView_lightTheme_no_location.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e8cd4c5da4b83b8278301189df83c6ecea44cddd3eb8217e4d38f82d90a1555
-size 24065
+oid sha256:ef8e751410f259e529b8af94654257036d0b9dedf46c0a2e76c2ab015baaade1
+size 23121

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.profile_ProfileViewScreenshotTest_profileView_lightTheme_logged.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.profile_ProfileViewScreenshotTest_profileView_lightTheme_logged.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:69d536473ebc523e1726e4543d26b15da482aa83dfeb4b34ab934b79d360aa7a
-size 19585
+oid sha256:df5d6a419a122587a31718800d598902bce91dbbd72e31486a3ea37715ec7a91
+size 18782

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.resetPassword_ResetPasswordViewScreenShotTest_resetPasswordView_lightTheme_empty.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.resetPassword_ResetPasswordViewScreenShotTest_resetPasswordView_lightTheme_empty.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5c38ce9ed6d659f469a3121a3898ddba6778851d017f2da67bbf6e44607ccde
-size 24600
+oid sha256:b389604972977622bddff799255e50caf62cb980c45300c4f1bd27986931b34e
+size 24332

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.resetPassword_ResetPasswordViewScreenShotTest_resetPasswordView_lightTheme_passwords_errors.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.resetPassword_ResetPasswordViewScreenShotTest_resetPasswordView_lightTheme_passwords_errors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8196e670fca78b22c1a4925324a09d3afec3de72848a1316d81f127d3c0d30b7
-size 30047
+oid sha256:9f20f532fd726661796ee4b3bf5da124086c82799fd03ca06ff42c6482cece9e
+size 29230

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.welcome_WelcomeViewScreenshotTest_welcomeView_lightTheme_data.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.welcome_WelcomeViewScreenshotTest_welcomeView_lightTheme_data.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc76a98fe68566f965bc20203845a04d0d756dbe2224a8c9e3c70a9fbda7c884
-size 19586
+oid sha256:8fccdf8e041eb468bf54644c5b107d8c622c2aef57431a652aefe2ea3ac907cd
+size 19588

--- a/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.welcome_WelcomeViewScreenshotTest_welcomeView_lightTheme_withDeviceId.png
+++ b/view/src/test/snapshots/images/cmm.apps.esmorga.view.screenshot.welcome_WelcomeViewScreenshotTest_welcomeView_lightTheme_withDeviceId.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc76a98fe68566f965bc20203845a04d0d756dbe2224a8c9e3c70a9fbda7c884
-size 19586
+oid sha256:37d486e14611a56dc5c3dc1d0266183489e83bd6b14b5f0b152cc324e92447f5
+size 20395


### PR DESCRIPTION
- Updated test screenshots to reflect current UI after fixing bold issue in PR #133

- Also changed the max difference accepted by Paparazzi to force fails when text changes. If this becomes an issue in the future, we may need to include a dynamic parameter to be set per test.